### PR TITLE
Fix resetting flags on "Clear"

### DIFF
--- a/=
+++ b/=
@@ -77,7 +77,7 @@ done
 action=$(echo -e "Copy to clipboard\nClear\nClose" | $menu "$@" -p "= $answer")
 
 case $action in
-    "Clear") $0 ;;
+    "Clear") $0 "" "--dmenu=$menu" "--" "$@" ;;
     "Copy to clipboard") echo -n "$answer" | xclip -selection clipboard ;;
     "Close") ;;
     "") ;;


### PR DESCRIPTION
Options set with the `--dmenu` flag or after the `--` flag were reset on `Clear` previously. 

This appears to have been caused by commit 232940d8ee05f927bb18f127fc7066ba4466f486 as a way to fix displaying `true` on `Clear`, however, this fixes that by setting the first argument as an empty string, which will cause `[ -n "$1" ]` to fail. Overall this is a workaround for a bigger issue, since if someone wants to pass their own CLI arguments to this they will also need to set the first argument to `""`, which is not very good UX.